### PR TITLE
19장 오탈자 반영

### DIFF
--- a/19.md
+++ b/19.md
@@ -151,7 +151,7 @@ const obj = Object.create(null);
 // obj는 Object.__proto__를 상속받을 수 없다.
 console.log(obj.__proto__); // undefined
 
-// 따라서 Object.getPrototypeOf 메서드를 사용하는 편이 좋다.
+// 따라서 __proto__보다 Object.getPrototypeOf 메서드를 사용하는 편이 좋다.
 console.log(Object.getPrototypeOf(obj)); // null
 ```
 
@@ -284,7 +284,6 @@ console.log(obj.constructor === Object); // true
 
 ```javascript
 // 2. Object 생성자 함수에 의한 객체 생성
-// Object 생성자 함수는 new 연산자와 함께 호출하지 않아도 new 연산자와 함께 호출한 것과 동일하게 동작한다.
 // 인수가 전달되지 않았을 때 추상 연산 OrdinaryObjectCreate를 호출하여 빈 객체를 생성한다.
 let obj = new Object();
 console.log(obj); // {}
@@ -996,7 +995,7 @@ const person = {
   address: 'Seoul'
 };
 
-// for...in 문의 변수 prop에 person 객체의 프로퍼티 키가 할당된다.
+// for...in 문의 변수 key에 person 객체의 프로퍼티 키가 할당된다.
 for (const key in person) {
   console.log(key + ': ' + person[key]);
 }


### PR DESCRIPTION
안녕하세요 :)

19장 책 내용이 틀린 부분, 코드의 주석이 다른 부분이 있는 것 같아 수정하여 PR 드려봅니다.

- 19-09: 주석
- 19-18: 주석
- p.287: 따라서 **프로토타입 체인은 상속과 프로퍼티 검색을 위한 메커니즘**이라고 할 수 있다. (← 책에 마침표 없음)
- p.300: 제일 위 주석에 오타가 있다고 판단됩니다. `Object.create(prototype[, propertiesObject])` → `Object.create(prototype, [propertiesObject])` ( `,` 위치)
- 19-64: 책과 예제 코드의 내용은 동일하나, 주석(책과 예제 코드)의 `prop`이 `key`로 변경되는 게 맞다고 생각합니다.
- p.308: 마지막 문단 `Object.prototype.string` → `Object.prototype.toString` 인 것 같습니다.