### PR TITLE
예제 21-19 console.log(x) 출력 결과 주석 오류

### DIFF
--- a/21.md
+++ b/21.md
@@ -262,7 +262,7 @@ function foo() {
   eval('var x = 2; console.log(x);'); // 2
   // let, const 키워드를 사용한 변수 선언문은 strict mode가 적용된다.
   eval('const x = 3; console.log(x);'); // 3
-  console.log(x); // 2
+  console.log(x); // 3
 }
 
 foo();


### PR DESCRIPTION
안녕하세요.
331 페이지 [예제 21-19]에서 `console.log(x)`의 출력 결과 주석이 실제 실행 결과와 다른 것 같아 PR 올립니다.


```javascript
const x = 1;

function foo() {
  eval('var x = 2; console.log(x);'); // 2
  // let, const 키워드를 사용한 변수 선언문은 strict mode가 적용된다.
  eval('const x = 3; console.log(x);'); // 3
  console.log(x); // 2 <- ❗ 이 부분입니다.
}

foo();
console.log(x); // 1
```

```javascript
console.log(x); // 3 <- 실제로는 3이 출력됩니다.
```

정오표에도 해당 내용이 없는 것 같아 다음과 같이 주석 수정하여 PR 올립니다. 확인 부탁드립니다.
감사합니다.
